### PR TITLE
Add install-chuni-tools.user.js file

### DIFF
--- a/install-chuni-tools.user.js
+++ b/install-chuni-tools.user.js
@@ -1,0 +1,16 @@
+// ==UserScript==
+// @name         run chuni-tools on all chunithm-net pages
+// @version      0.1
+// @description  run chuni-tools on all chunithm-net pages
+// @author       evnchn
+// @match        https://chunithm-net-eng.com/*
+// @icon         data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==
+// @grant        none
+// ==/UserScript==
+
+(function () {
+    'use strict';
+    const s = document.createElement('script');
+    s.src = 'https://dogeon188.github.io/chuni-tools/scripts/chuni-tools.js?t=' + Math.floor(Date.now() / 60000);
+    document.body.append(s);
+})();


### PR DESCRIPTION
Refer to https://github.com/myjian/mai-tools/blob/gh-pages/install-mai-tools.user.js

The proposed userscript is _almost_ exactly identical. It simply runs the same content as the bookmarklet automatically per page. 

This should be 100% compatible to any future changes to chuni-tools. Though, please merge ASAP in case of potential merge failure caused by newly added or changed files. 