### PR TITLE
Fix best rating table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@ src/lib/paraglide
 
 # Dev
 /.cert
+/.vscode
+/messages
+/project.inlang
+

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The chart constant data is from [CHUNITHM譜面定数メインフレーム](http
 **Setup https certificate** <br>
 chuni-tools can only be used with https. Install a tool such as [mkcert](https://github.com/FiloSottile/mkcert) and run the following.
 ```sh
-mkdir cert
+mkdir .cert
 cd .cert
 mkcert -cert-file cert.pem -key-file key.pem localhost
 cd ..

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The chart constant data is from [CHUNITHM譜面定数メインフレーム](http
 chuni-tools can only be used with https. Install a tool such as [mkcert](https://github.com/FiloSottile/mkcert) and run the following.
 ```sh
 mkdir cert
-cd cert
+cd .cert
 mkcert -cert-file cert.pem -key-file key.pem localhost
 cd ..
 ```

--- a/README.md
+++ b/README.md
@@ -14,8 +14,42 @@ The chart constant data is from [CHUNITHM譜面定数メインフレーム](http
 
 ## Dev
 
-To initialize the repository, first use `bun install` or `npm install` to install the dependencies. After that, use `bun dev` or `npm run dev` to start the development server for the website part.
+**Setup https certificate** <br>
+chuni-tools can only be used with https. Install a tool such as [mkcert](https://github.com/FiloSottile/mkcert) and run the following.
+```sh
+mkdir cert
+cd cert
+mkcert -cert-file cert.pem -key-file key.pem localhost
+cd ..
+```
 
-To build the bookmarklet script, first create a certificate with any tool you like (e.g. [mkcert](https://github.com/FiloSottile/mkcert)) at `./cert`, then run `bun dev:scripts` or `npm run dev:scripts`. This will start a development server hosting from `./build`. Due to technical limitations, you still need to manually build the bookmarklet script separately with `bun build:scripts` or `npm run build:scripts`, which will output the script to `./build/scripts/*.js`.
+**Init Repo**
+```sh
+npm install
+# OR
+bun install
+```
+**Build scripts** <br>
+Due to technical limitations, you still need to manually build the bookmarklet script separately with the following command
+```sh
+npm run build:scripts
+# OR 
+bun build:scripts
+```
+The scripts will be generated at `./build/scripts/`.
 
-With `bun run build` or `npm run build`, you can build and compile the code to `./build`, then GitHub Pages will handle the rest.
+**Run Dev Environment**
+```
+npm run dev
+# OR
+bun dev
+```
+chuni-tools should be running on localhost and can be accessed at `https://localhost:5173`. You may get a warning about insecure certificate, you can safely ignore it.
+
+**Build Production Environment**
+```sh
+npm run build
+# OR
+bun run build
+```
+then GitHub Pages will handle the rest.

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -43,7 +43,8 @@
 		"tabs": {
 			"best": "BEST",
 			"current": "CURRENT",
-			"recent": "RECENT"
+			"recent": "RECENT",
+			"old": "OLD"
 		},
 		"press_to_start": "Analyze Rating",
 		"settings": {

--- a/i18n/locales/jp.json
+++ b/i18n/locales/jp.json
@@ -34,7 +34,8 @@
 		"tabs": {
 			"best": "ベスト",
 			"current": "新曲",
-			"recent": "リーセント"
+			"recent": "リーセント",
+			"old": "旧曲"
 		},
 		"press_to_start": "レコードビューアへ",
 		"settings": {

--- a/i18n/locales/zh-tw.json
+++ b/i18n/locales/zh-tw.json
@@ -35,7 +35,8 @@
 		"tabs": {
 			"best": "BEST",
 			"current": "CURRENT",
-			"recent": "RECENT"
+			"recent": "RECENT",
+			"old": "OLD"
 		},
 		"press_to_start": "分析遊戲成績",
 		"settings": {

--- a/src/routes/record-viewer/+page.svelte
+++ b/src/routes/record-viewer/+page.svelte
@@ -33,7 +33,7 @@
 
 	const routeChange: EventHandler<HashChangeEvent, Window> = (event) => {
 		$_page = (new URL(event.newURL).hash.slice(1) as typeof $_page) || 'best'
-		if (!['best', 'current', 'recent'].includes($_page)) {
+		if (!['best', 'current', 'recent', 'old'].includes($_page)) {
 			$_page = 'best'
 		}
 	}
@@ -72,19 +72,22 @@
 					/* $filterConstMax >= record.const */
 					$filterConstMax > record.const - 0.05 &&
 					/* record.const >= $filterConstMin */
-					record.const + 0.05 > $filterConstMin &&
-					/* remove charts from current version */
-					!$recentRecord.map(record => record.title).includes(record.title)
+					record.const + 0.05 > $filterConstMin
 			)
 	)
+	
+	const old30 = derived([filteredBestRecord], ([$filteredBestRecord]) => 
+		$filteredBestRecord.filter((record) => !$recentRecord.map(record => record.title).includes(record.title))
+	);
+	
+	const shownRecordsMap = {
+		'best': filteredBestRecord,
+		'current': recentRecord,
+		'recent': playHistory,
+		'old': old30,
+	}
 
-	const shownRecords = $derived(
-		$_page === 'best'
-			? filteredBestRecord
-			: $_page === 'current'
-				? recentRecord
-				: playHistory
-	)
+	const shownRecords = $derived(shownRecordsMap[$_page] || recentRecord)
 
 	// rank counts
 
@@ -207,13 +210,22 @@
 			{m['viewer.tabs.current']()}
 		</h4>
 	</a>
-	<a id="recent" href="#recent" class="!decoration-none !no-underline">
+	<!-- <a id="recent" href="#recent" class="!decoration-none !no-underline">
 		<h4
 			class="!mb-0"
 			class:!text-textc-normal={$_page === 'recent'}
 			class:!text-textc-dim={$_page !== 'recent'}
 		>
 			{m['viewer.tabs.recent']()}
+		</h4>
+	</a> -->
+	<a id="old" href="#old" class="!decoration-none !no-underline">
+		<h4
+			class="!mb-0"
+			class:!text-textc-normal={$_page === 'old'}
+			class:!text-textc-dim={$_page !== 'old'}
+		>
+			{m['viewer.tabs.old']()}
 		</h4>
 	</a>
 </header>

--- a/src/routes/record-viewer/+page.svelte
+++ b/src/routes/record-viewer/+page.svelte
@@ -72,7 +72,9 @@
 					/* $filterConstMax >= record.const */
 					$filterConstMax > record.const - 0.05 &&
 					/* record.const >= $filterConstMin */
-					record.const + 0.05 > $filterConstMin
+					record.const + 0.05 > $filterConstMin &&
+					/* remove charts from current version */
+					!$recentRecord.map(record => record.title).includes(record.title)
 			)
 	)
 

--- a/src/routes/record-viewer/+page.ts
+++ b/src/routes/record-viewer/+page.ts
@@ -1,3 +1,3 @@
 import { writable } from 'svelte/store'
 
-export const _page = writable<'best' | 'current' | 'recent'>('best')
+export const _page = writable<'best' | 'current' | 'recent' | 'old'>('best')


### PR DESCRIPTION
chuni-tools gets the "best" (aka old 30) from chuninet by requesting bestRecord. However, the values returned also include charts from the current version. This change filters out the charts from current version, so it matches "best" on chuninet.

I've also included an update to README because it felt a bit unclear before